### PR TITLE
Check form value for auth

### DIFF
--- a/nanoauth.go
+++ b/nanoauth.go
@@ -39,7 +39,13 @@ func (self Auth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if check && req.Header.Get(self.Header) != self.Token {
+	auth := ""
+	if auth = req.Header.Get(self.Header); auth == "" {
+		// check form value (case sensitive) if header not set
+		auth = req.FormValue(self.Header)
+	}
+
+	if check && auth != self.Token {
 		rw.WriteHeader(http.StatusUnauthorized)
 		return
 	}

--- a/nanoauth_test.go
+++ b/nanoauth_test.go
@@ -55,12 +55,11 @@ func TestListenServe(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// test good request
-	req, err := newReq(address1, "/")
+	req, err := newReq(address1, "/?X-NANOBOX-TOKEN=$ECRET")
 	if err != nil {
 		t.Errorf("Failed to create request - %v", err)
 		t.FailNow()
 	}
-	req.Header.Add("X-NANOBOX-TOKEN", "$ECRET")
 	req.Host = "nanobox-router.test"
 
 	resp, err := getIt(req)


### PR DESCRIPTION
This allows for a token to be passed in via form data (web browser ease), as well as skips token verification if no token is configured.
