### PR TITLE
Small security fixes

### DIFF
--- a/nanoauth.go
+++ b/nanoauth.go
@@ -5,6 +5,7 @@
 package nanoauth
 
 import (
+	"crypto/subtle"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -56,7 +57,7 @@ func (self *Auth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			auth = req.FormValue(self.Header)
 		}
 
-		if auth != self.Token {
+		if subtle.ConstantTimeCompare([]byte(auth), []byte(self.Token)) == 0 {
 			rw.WriteHeader(http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Just two small fixes:

1. Remove the 'check' variable. It seems dangerous to me to leave it around, since a small error can mean the verification is turned off.
2. Resolve a [timing attack](https://en.wikipedia.org/wiki/Timing_attack) that would make it possible for an attacker to figure out the auth token.